### PR TITLE
Fast call failure

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,6 +1,6 @@
 # For available configuration options, see:
 #   https://github.com/testdouble/standard
-ruby_version: 2.6
+ruby_version: 3.2
 
 ignore:
   - example/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,5 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 13.0"
-
 gem "rspec", "~> 3.0"
-
 gem "standard", "~> 1.3"

--- a/database_cleaner-spanner.gemspec
+++ b/database_cleaner-spanner.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "google-cloud-spanner", "~> 2.10"
+  spec.add_dependency "google-cloud-spanner", "~> 2.22"
   spec.add_dependency "database_cleaner-core", "~> 2.0.0"
 
   spec.add_development_dependency "simplecov"

--- a/lib/database_cleaner/spanner/deletion.rb
+++ b/lib/database_cleaner/spanner/deletion.rb
@@ -151,7 +151,7 @@ module DatabaseCleaner
         config = ::ActiveRecord::Base.configurations.configs_for(name: name.to_s).configuration_hash
 
         # Keep metadata tables
-        @except << ::ActiveRecord::SchemaMigration.table_name # schema_migrations
+        @except << ::ActiveRecord::Base.connection.schema_migration.table_name # schema_migrations
         @except << ::ActiveRecord::Base.internal_metadata_table_name # ar_internal_metadata
 
         Google::Cloud::Spanner.new(

--- a/lib/database_cleaner/spanner/table_dependency.rb
+++ b/lib/database_cleaner/spanner/table_dependency.rb
@@ -1,4 +1,3 @@
-require "set"
 require "tsort"
 
 module DatabaseCleaner

--- a/spec/local.env
+++ b/spec/local.env
@@ -1,0 +1,1 @@
+SPANNER_EMULATOR_HOST="localhost:9010"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,15 @@ require "database_cleaner/spanner"
 
 require "google/cloud/spanner"
 
+dotenv = File.expand_path("local.env", __dir__)
+if File.exist?(dotenv)
+  File.read(dotenv).each_line do |line|
+    line.split("=").tap do |key, value|
+      ENV[key] = value.gsub(/^['"]|['"]$/, "")
+    end
+  end
+end
+
 require_relative "spanner_admin"
 
 RSpec.configure do |config|


### PR DESCRIPTION
Two items. 

### open transaction timeouts 

When the Spanner local emulator has hung open transactions, the default connection timeout of 60s kills the whole test process silently for a minute. This sucks. [See documentation of the issue here](https://gist.github.com/abachman/1c895656b094cfa92785f7703043837a#file-readme-md). This PR adds query options to die quickly if the query fails to return anything in 3 seconds.

### rails 7.1 compatibility 

See [database_cleaner-active_record#78](https://github.com/DatabaseCleaner/database_cleaner-active_record/pull/78) for similar change.

Rails 7.0 introduced `::ActiveRecord::Base.connection.schema_migration.table_name` as a way of getting the schema migrations metadata table name. Rails 7.1 took away `::ActiveRecord::SchemaMigration.table_name`.
