### PR TITLE
fix: Support rails 7.2.

### DIFF
--- a/lib/database_cleaner/spanner/deletion.rb
+++ b/lib/database_cleaner/spanner/deletion.rb
@@ -151,7 +151,11 @@ module DatabaseCleaner
         config = ::ActiveRecord::Base.configurations.configs_for(name: name.to_s).configuration_hash
 
         # Keep metadata tables
-        @except << ::ActiveRecord::Base.connection.schema_migration.table_name # schema_migrations
+        @except << if ::ActiveRecord.version < ::Gem::Version.new("7.2")
+                     ::ActiveRecord::Base.connection.schema_migration.table_name
+                   else
+                     ::ActiveRecord::Base.connection_pool.schema_migration.table_name
+                   end
         @except << ::ActiveRecord::Base.internal_metadata_table_name # ar_internal_metadata
 
         Google::Cloud::Spanner.new(


### PR DESCRIPTION
Fix for missing 'ActiveRecord::Base.connection.schema_migration.table_name' in rails 7.2.

see:
- https://github.com/DatabaseCleaner/database_cleaner-active_record/pull/101